### PR TITLE
Suggest usage of pyronn_layers as a submodule in tensorflow repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ To achieve this, the PRYO-NN-Layers repository need to be cloned into a 'pyronn_
 
 .. code-block:: bash
 
-    git clone https://github.com/csyben/PYRO-NN-Layers pyronn_layers
+    git submodule add https://github.com/csyben/PYRO-NN-Layers pyronn_layers
 
 Next step is to patch the Tensorflow build process such that all C++ and CUDA files in the pyronn_layers folder are compiled and
 made available under the pyronn_layers namespace at the python level. Select the respective patch for the choosen release version of Tensorflow.


### PR DESCRIPTION
I was wondering whether we should suggest usage submodules in `README.rst`.
Then, people can push their patched Tensorflow plus a specific pyronn version to their repo.